### PR TITLE
Install mb2nl theme + mb2shortcodes filter from private theme repo (#88)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,13 +4,23 @@ on:
   push:
     branches:
       - main
+  repository_dispatch:
+    types: [theme-updated]     # fired by moodle-new-theme on its push to main
+  workflow_dispatch: {}         # manual rebuild button (also used to test the PR branch)
 
 jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout moodle-docker
+        uses: actions/checkout@v4
+
+      - name: Checkout private theme/filter zips
+        uses: actions/checkout@v4
+        with:
+          repository: the-pilot-club/moodle-new-theme
+          ssh-key: ${{ secrets.NEW_THEME_DEPLOY_KEY }}
+          path: new-theme-src       # lands inside the build context root
 
       - name: Gather metadata
         id: meta
@@ -32,7 +42,7 @@ jobs:
         with:
           registry: registry.digitalocean.com
           username: ${{ secrets.DO_REGISTRY_USERNAME }}
-          password: ${{ secrets.DO_REGISTRY_USERNAME }}
+          password: ${{ secrets.DO_REGISTRY_PASSWORD }}
 
       - name: Build and push
         uses: docker/build-push-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
 config-dev.php
 Dockerfile-dev
+
+# CI checks the private (paid) theme/filter zips out here at build time.
+# Never commit them to this public repo.
+new-theme-src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,17 @@ RUN set -ex \
     && curl -L https://github.com/the-pilot-club/moodle-tpc-local/archive/${MOODLE_LOCAL_TPC_COMMIT}.tar.gz | tar -C /var/www/html/local/tpc --strip-components=1 -xz \
     && chown -R www-data:www-data /var/www/html
 
+# Install the New Learning theme (theme_mb2nl) + mb2 shortcodes filter (filter_mb2shortcodes).
+# The zips come from the private the-pilot-club/moodle-new-theme repo, which CI checks out
+# into ./new-theme-src/ in the build context (see .github/workflows/push.yml). Filenames are
+# version-specific, so match by prefix (case-insensitive) to survive future theme updates.
+COPY new-theme-src/ /tmp/new-theme/
+RUN set -ex \
+    && unzip -q /tmp/new-theme/theme_*.[Zz][Ii][Pp]  -d /var/www/html/theme/ \
+    && unzip -q /tmp/new-theme/FILTER_*.[Zz][Ii][Pp] -d /var/www/html/filter/ \
+    && rm -rf /tmp/new-theme \
+    && chown -R www-data:www-data /var/www/html/theme/mb2nl /var/www/html/filter/mb2shortcodes
+
 
 
 # Configure PHP/Apache


### PR DESCRIPTION
Extract the New Learning theme and shortcodes filter zips at image-build time and place them at /var/www/html/theme/mb2nl and /var/www/html/filter/mb2shortcodes. The zips live in the private the-pilot-club/moodle-new-theme repo, which CI now checks out into ./new-theme-src/ via a read-only deploy key before building.

Also:
- Rebuild the image automatically when the theme repo changes, via a repository_dispatch (theme-updated) trigger, plus a manual workflow_dispatch button.
- Fix the DigitalOcean registry login to use DO_REGISTRY_PASSWORD.
- gitignore new-theme-src/ so the private/paid zips never get committed to this public repo.